### PR TITLE
feat: add support for sentinel columns with serde serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 Cargo.lock
+.idea/
+tmp/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1.6.0", features = ["macros"] }
 
 [dev-dependencies]
 insta = "1.14.1"
+test-case = "3"
 serde_repr = "0.1.7"
 serde_bytes = "0.11.5"
 trybuild = "1.0.42"

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -71,10 +71,23 @@ fn generate_field(dst: &mut impl Write, column: &Column, options: &Options) -> R
     Ok(())
 }
 
+fn is_sentinel(column_name: &str, options: &Options) -> bool {
+    options.sentinels.iter().any(|s| s == column_name)
+}
+
+fn sentinel_mod_name(column_name: &str) -> String {
+    format!("sentinel_{}", column_name.to_snake_case())
+}
+
 fn make_attribute(column: &Column, options: &Options) -> Result<Option<String>> {
     if options.bytes.iter().any(|b| b == &column.name) {
         // Works also for `Option<_>`.
         return Ok(Some(r#"    #[serde(with = "serde_bytes")]"#.into()));
+    }
+
+    if is_sentinel(&column.name, options) {
+        let mod_name = sentinel_mod_name(&column.name);
+        return Ok(Some(format!(r#"    #[serde(with = "{}")]"#, mod_name)));
     }
 
     // Add nothing if the column is overrided by name or type.
@@ -143,6 +156,10 @@ fn temporal_path(temporal_mode: Temporal, ty: &str, prec: Option<&u32>) -> Resul
 }
 
 fn make_type(column: &Column, options: &Options) -> Result<String> {
+    if is_sentinel(&column.name, options) {
+        let (rust_type, _) = sentinel_info(&column.type_)?;
+        return Ok(format!("Option<{}>", rust_type));
+    }
     do_make_type(&column.name, &column.type_, options)
 }
 
@@ -314,6 +331,103 @@ fn prepare_name_ident(name: &str) -> String {
     }
 }
 
+fn sentinel_info(sql_type: &SqlType) -> Result<(&'static str, &'static str)> {
+    Ok(match sql_type {
+        SqlType::String => ("String", r#""""#),
+        SqlType::UInt8 => ("u8", "0u8"),
+        SqlType::UInt16 => ("u16", "0u16"),
+        SqlType::UInt32 => ("u32", "0u32"),
+        SqlType::UInt64 => ("u64", "0u64"),
+        SqlType::UInt128 => ("u128", "0u128"),
+        SqlType::Int8 => ("i8", "0i8"),
+        SqlType::Int16 => ("i16", "0i16"),
+        SqlType::Int32 => ("i32", "0i32"),
+        SqlType::Int64 => ("i64", "0i64"),
+        SqlType::Int128 => ("i128", "0i128"),
+        SqlType::Float32 => ("f32", "0f32"),
+        SqlType::Float64 => ("f64", "0f64"),
+        _ => bail!("-N is not supported for type {}", sql_type),
+    })
+}
+
+fn validate_sentinel(column: &Column, options: &Options) -> Result<()> {
+    if matches!(column.type_, SqlType::Nullable(_)) {
+        bail!(
+            "column `{}` is already Nullable; -N is not needed",
+            column.name
+        );
+    }
+    if find_override(&column.name, &column.type_, options).is_some() {
+        bail!(
+            "column `{}` has both -N and -O/-T; this combination is not supported",
+            column.name
+        );
+    }
+    Ok(())
+}
+
+fn generate_sentinel_modules(dst: &mut impl Write, table: &Table, options: &Options) -> Result<()> {
+    for column in &table.columns {
+        if !is_sentinel(&column.name, options) {
+            continue;
+        }
+
+        validate_sentinel(column, options)?;
+
+        let mod_name = sentinel_mod_name(&column.name);
+        let (rust_type, default_lit) = sentinel_info(&column.type_)
+            .with_context(|| format!("sentinel column `{}`", column.name))?;
+
+        writeln!(dst, "mod {} {{", mod_name)?;
+        writeln!(dst, "    use serde::{{Deserializer, Serializer}};")?;
+        writeln!(dst)?;
+        writeln!(
+            dst,
+            "    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<{}>, D::Error>",
+            rust_type
+        )?;
+        writeln!(dst, "    where")?;
+        writeln!(dst, "        D: Deserializer<'de>,")?;
+        writeln!(dst, "    {{")?;
+        writeln!(
+            dst,
+            "        let value = <{} as serde::Deserialize>::deserialize(deserializer)?;",
+            rust_type
+        )?;
+        writeln!(dst, "        if value == {} {{", default_lit)?;
+        writeln!(dst, "            Ok(None)")?;
+        writeln!(dst, "        }} else {{")?;
+        writeln!(dst, "            Ok(Some(value))")?;
+        writeln!(dst, "        }}")?;
+        writeln!(dst, "    }}")?;
+        writeln!(dst)?;
+        writeln!(
+            dst,
+            "    pub fn serialize<S>(value: &Option<{}>, serializer: S) -> Result<S::Ok, S::Error>",
+            rust_type
+        )?;
+        writeln!(dst, "    where")?;
+        writeln!(dst, "        S: Serializer,")?;
+        writeln!(dst, "    {{")?;
+        writeln!(dst, "        match value {{")?;
+        writeln!(
+            dst,
+            "            Some(v) => serde::Serialize::serialize(v, serializer),",
+        )?;
+        writeln!(
+            dst,
+            "            None => serde::Serialize::serialize(&{}, serializer),",
+            default_lit
+        )?;
+        writeln!(dst, "        }}")?;
+        writeln!(dst, "    }}")?;
+        writeln!(dst, "}}")?;
+        writeln!(dst)?;
+    }
+
+    Ok(())
+}
+
 pub fn generate(table: &Table, options: &Options) -> Result<String> {
     let mut code = String::new();
     generate_prelude(&mut code, options).context("failed to generate a prelude")?;
@@ -321,5 +435,65 @@ pub fn generate(table: &Table, options: &Options) -> Result<String> {
     generate_row(&mut code, table, options).context("failed to generate a row")?;
     writeln!(code)?;
     generate_enums(&mut code, table, options).context("failed to generate enums")?;
+    generate_sentinel_modules(&mut code, table, options)
+        .context("failed to generate sentinel serde modules")?;
     Ok(code.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use structopt::StructOpt;
+    use test_case::test_case;
+
+    use super::*;
+
+    fn make_table(columns: Vec<(&str, SqlType)>) -> Table {
+        Table {
+            columns: columns
+                .into_iter()
+                .map(|(name, type_)| Column {
+                    name: name.into(),
+                    type_,
+                    comment: String::new(),
+                })
+                .collect(),
+        }
+    }
+
+    fn make_options(args: &[&str]) -> Options {
+        Options::from_iter(args)
+    }
+
+    #[test_case(SqlType::Nullable(Box::new(SqlType::UInt32)) ; "nullable")]
+    #[test_case(SqlType::Enum8(vec![])                       ; "enum8")]
+    #[test_case(SqlType::Array(Box::new(SqlType::String))    ; "array")]
+    #[test_case(SqlType::Date                                ; "date")]
+    #[test_case(SqlType::UUID                                ; "uuid")]
+    #[test_case(SqlType::Bool                                ; "bool")]
+    fn test_sentinel_rejected_for(sql_type: SqlType) {
+        let table = make_table(vec![("col", sql_type)]);
+        let options = make_options(&["ch2rs", "t", "-S", "-D", "-N", "col"]);
+        assert!(generate(&table, &options).is_err());
+    }
+
+    #[test_case(SqlType::String,  "Option<String>" ; "string")]
+    #[test_case(SqlType::UInt8,   "Option<u8>"     ; "u8")]
+    #[test_case(SqlType::UInt16,  "Option<u16>"    ; "u16")]
+    #[test_case(SqlType::UInt32,  "Option<u32>"    ; "u32")]
+    #[test_case(SqlType::UInt64,  "Option<u64>"    ; "u64")]
+    #[test_case(SqlType::UInt128, "Option<u128>"   ; "u128")]
+    #[test_case(SqlType::Int8,    "Option<i8>"     ; "i8")]
+    #[test_case(SqlType::Int16,   "Option<i16>"    ; "i16")]
+    #[test_case(SqlType::Int32,   "Option<i32>"    ; "i32")]
+    #[test_case(SqlType::Int64,   "Option<i64>"    ; "i64")]
+    #[test_case(SqlType::Int128,  "Option<i128>"   ; "i128")]
+    #[test_case(SqlType::Float32, "Option<f32>"    ; "f32")]
+    #[test_case(SqlType::Float64, "Option<f64>"    ; "f64")]
+    fn test_sentinel_generates(sql_type: SqlType, expected_type: &str) {
+        let table = make_table(vec![("col", sql_type)]);
+        let options = make_options(&["ch2rs", "t", "-S", "-D", "--owned", "-N", "col"]);
+        let code = generate(&table, &options).unwrap();
+        assert!(code.contains(&format!("pub col: {}", expected_type)));
+        assert!(code.contains("mod sentinel_col"));
+    }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -46,6 +46,10 @@ pub struct Options {
     /// Add `#[derive(<trait>)]` to the generated types.
     #[structopt(long = "derive", number_of_values = 1, name = "trait")]
     pub derives: Vec<String>,
+    /// Treat the column as Option, mapping the type's default value to None.
+    /// The sentinel is derived from the ClickHouse type (e.g. "" for String, 0 for UInt32).
+    #[structopt(short = "N", number_of_values = 1)]
+    pub sentinels: Vec<String>,
 
     /// Temporal mapping mode
     #[structopt(long = "temporal", default_value = "raw", possible_values=&["raw", "time", "chrono"])]
@@ -167,6 +171,14 @@ impl Options {
 
         for b in bytes {
             let _ = writeln!(&mut s, "    -B '{}' \\", b);
+        }
+
+        // -N
+        let mut sentinels = self.sentinels.iter().collect::<Vec<_>>();
+        sentinels.sort();
+
+        for n in sentinels {
+            let _ = writeln!(&mut s, "    -N '{}' \\", n);
         }
 
         // -I

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -65,6 +65,8 @@ const CREATE_TABLE_DDL: &str = "
         map_str     Map(String, String),
         map_f32     Map(String, Float32),
 
+        str_sentinel String DEFAULT '',
+
         default     DEFAULT u16,
         material    MATERIALIZED u16,
         alias       ALIAS u16,
@@ -124,6 +126,8 @@ async fn generate_all() {
                     "blob=Vec<u8>",
                     "-B",
                     "blob",
+                    "-N",
+                    "str_sentinel",
                     "-I",
                     "ignored",
                     "--derive",

--- a/tests/snapshots/all@-D.snap
+++ b/tests/snapshots/all@-D.snap
@@ -16,6 +16,7 @@ ch2rs ch2rs_test -D \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -88,6 +89,8 @@ pub struct Row<'a> {
     pub str_opt: Option<&'a str>,
     pub map_str: Vec<(&'a str, &'a str, )>,
     pub map_f32: Vec<(&'a str, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -111,4 +114,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-D_--owned.snap
+++ b/tests/snapshots/all@-D_--owned.snap
@@ -16,6 +16,7 @@ ch2rs ch2rs_test -D --owned \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -88,6 +89,8 @@ pub struct Row {
     pub str_opt: Option<String>,
     pub map_str: Vec<(String, String, )>,
     pub map_f32: Vec<(String, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -111,4 +114,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-D_--owned_chrono.snap
+++ b/tests/snapshots/all@-D_--owned_chrono.snap
@@ -17,6 +17,7 @@ ch2rs ch2rs_test -D --owned \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -113,6 +114,8 @@ pub struct Row {
     pub str_opt: Option<String>,
     pub map_str: Vec<(String, String, )>,
     pub map_f32: Vec<(String, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -136,4 +139,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-D_--owned_raw.snap
+++ b/tests/snapshots/all@-D_--owned_raw.snap
@@ -16,6 +16,7 @@ ch2rs ch2rs_test -D --owned \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -88,6 +89,8 @@ pub struct Row {
     pub str_opt: Option<String>,
     pub map_str: Vec<(String, String, )>,
     pub map_f32: Vec<(String, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -111,4 +114,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-D_--owned_time.snap
+++ b/tests/snapshots/all@-D_--owned_time.snap
@@ -17,6 +17,7 @@ ch2rs ch2rs_test -D --owned \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -113,6 +114,8 @@ pub struct Row {
     pub str_opt: Option<String>,
     pub map_str: Vec<(String, String, )>,
     pub map_f32: Vec<(String, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -136,4 +139,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-D__chrono.snap
+++ b/tests/snapshots/all@-D__chrono.snap
@@ -17,6 +17,7 @@ ch2rs ch2rs_test -D \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -113,6 +114,8 @@ pub struct Row<'a> {
     pub str_opt: Option<&'a str>,
     pub map_str: Vec<(&'a str, &'a str, )>,
     pub map_f32: Vec<(&'a str, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -136,4 +139,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-D__raw.snap
+++ b/tests/snapshots/all@-D__raw.snap
@@ -16,6 +16,7 @@ ch2rs ch2rs_test -D \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -88,6 +89,8 @@ pub struct Row<'a> {
     pub str_opt: Option<&'a str>,
     pub map_str: Vec<(&'a str, &'a str, )>,
     pub map_f32: Vec<(&'a str, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -111,4 +114,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-D__time.snap
+++ b/tests/snapshots/all@-D__time.snap
@@ -17,6 +17,7 @@ ch2rs ch2rs_test -D \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -113,6 +114,8 @@ pub struct Row<'a> {
     pub str_opt: Option<&'a str>,
     pub map_str: Vec<(&'a str, &'a str, )>,
     pub map_f32: Vec<(&'a str, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -136,4 +139,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-S.snap
+++ b/tests/snapshots/all@-S.snap
@@ -16,6 +16,7 @@ ch2rs ch2rs_test -S \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -88,6 +89,8 @@ pub struct Row<'a> {
     pub str_opt: Option<&'a str>,
     pub map_str: Vec<(&'a str, &'a str, )>,
     pub map_f32: Vec<(&'a str, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -111,4 +114,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-SD.snap
+++ b/tests/snapshots/all@-SD.snap
@@ -16,6 +16,7 @@ ch2rs ch2rs_test -S -D \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -89,6 +90,8 @@ pub struct Row<'a> {
     pub str_opt: Option<&'a str>,
     pub map_str: Vec<(&'a str, &'a str, )>,
     pub map_f32: Vec<(&'a str, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -114,4 +117,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-SD_--owned.snap
+++ b/tests/snapshots/all@-SD_--owned.snap
@@ -16,6 +16,7 @@ ch2rs ch2rs_test -S -D --owned \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -89,6 +90,8 @@ pub struct Row {
     pub str_opt: Option<String>,
     pub map_str: Vec<(String, String, )>,
     pub map_f32: Vec<(String, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -114,4 +117,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-SD_--owned_chrono.snap
+++ b/tests/snapshots/all@-SD_--owned_chrono.snap
@@ -17,6 +17,7 @@ ch2rs ch2rs_test -S -D --owned \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -114,6 +115,8 @@ pub struct Row {
     pub str_opt: Option<String>,
     pub map_str: Vec<(String, String, )>,
     pub map_f32: Vec<(String, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -139,4 +142,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-SD_--owned_raw.snap
+++ b/tests/snapshots/all@-SD_--owned_raw.snap
@@ -16,6 +16,7 @@ ch2rs ch2rs_test -S -D --owned \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -89,6 +90,8 @@ pub struct Row {
     pub str_opt: Option<String>,
     pub map_str: Vec<(String, String, )>,
     pub map_f32: Vec<(String, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -114,4 +117,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-SD_--owned_time.snap
+++ b/tests/snapshots/all@-SD_--owned_time.snap
@@ -17,6 +17,7 @@ ch2rs ch2rs_test -S -D --owned \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -114,6 +115,8 @@ pub struct Row {
     pub str_opt: Option<String>,
     pub map_str: Vec<(String, String, )>,
     pub map_f32: Vec<(String, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -139,4 +142,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-SD__chrono.snap
+++ b/tests/snapshots/all@-SD__chrono.snap
@@ -17,6 +17,7 @@ ch2rs ch2rs_test -S -D \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -114,6 +115,8 @@ pub struct Row<'a> {
     pub str_opt: Option<&'a str>,
     pub map_str: Vec<(&'a str, &'a str, )>,
     pub map_f32: Vec<(&'a str, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -139,4 +142,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-SD__raw.snap
+++ b/tests/snapshots/all@-SD__raw.snap
@@ -16,6 +16,7 @@ ch2rs ch2rs_test -S -D \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -89,6 +90,8 @@ pub struct Row<'a> {
     pub str_opt: Option<&'a str>,
     pub map_str: Vec<(&'a str, &'a str, )>,
     pub map_f32: Vec<(&'a str, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -114,4 +117,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-SD__time.snap
+++ b/tests/snapshots/all@-SD__time.snap
@@ -17,6 +17,7 @@ ch2rs ch2rs_test -S -D \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -114,6 +115,8 @@ pub struct Row<'a> {
     pub str_opt: Option<&'a str>,
     pub map_str: Vec<(&'a str, &'a str, )>,
     pub map_f32: Vec<(&'a str, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -139,4 +142,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-S_--owned.snap
+++ b/tests/snapshots/all@-S_--owned.snap
@@ -16,6 +16,7 @@ ch2rs ch2rs_test -S --owned \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -88,6 +89,8 @@ pub struct Row {
     pub str_opt: Option<String>,
     pub map_str: Vec<(String, String, )>,
     pub map_f32: Vec<(String, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -111,4 +114,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-S_--owned_chrono.snap
+++ b/tests/snapshots/all@-S_--owned_chrono.snap
@@ -17,6 +17,7 @@ ch2rs ch2rs_test -S --owned \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -113,6 +114,8 @@ pub struct Row {
     pub str_opt: Option<String>,
     pub map_str: Vec<(String, String, )>,
     pub map_f32: Vec<(String, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -136,4 +139,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-S_--owned_raw.snap
+++ b/tests/snapshots/all@-S_--owned_raw.snap
@@ -16,6 +16,7 @@ ch2rs ch2rs_test -S --owned \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -88,6 +89,8 @@ pub struct Row {
     pub str_opt: Option<String>,
     pub map_str: Vec<(String, String, )>,
     pub map_f32: Vec<(String, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -111,4 +114,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-S_--owned_time.snap
+++ b/tests/snapshots/all@-S_--owned_time.snap
@@ -17,6 +17,7 @@ ch2rs ch2rs_test -S --owned \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -113,6 +114,8 @@ pub struct Row {
     pub str_opt: Option<String>,
     pub map_str: Vec<(String, String, )>,
     pub map_f32: Vec<(String, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -136,4 +139,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-S__chrono.snap
+++ b/tests/snapshots/all@-S__chrono.snap
@@ -17,6 +17,7 @@ ch2rs ch2rs_test -S \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -113,6 +114,8 @@ pub struct Row<'a> {
     pub str_opt: Option<&'a str>,
     pub map_str: Vec<(&'a str, &'a str, )>,
     pub map_f32: Vec<(&'a str, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -136,4 +139,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-S__raw.snap
+++ b/tests/snapshots/all@-S__raw.snap
@@ -16,6 +16,7 @@ ch2rs ch2rs_test -S \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -88,6 +89,8 @@ pub struct Row<'a> {
     pub str_opt: Option<&'a str>,
     pub map_str: Vec<(&'a str, &'a str, )>,
     pub map_f32: Vec<(&'a str, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -111,4 +114,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }

--- a/tests/snapshots/all@-S__time.snap
+++ b/tests/snapshots/all@-S__time.snap
@@ -17,6 +17,7 @@ ch2rs ch2rs_test -S \
         -T 'Decimal(18, 9)=u64' \
         -O 'blob=Vec<u8>' \
         -B 'blob' \
+        -N 'str_sentinel' \
         -I 'ignored'
 */
 
@@ -113,6 +114,8 @@ pub struct Row<'a> {
     pub str_opt: Option<&'a str>,
     pub map_str: Vec<(&'a str, &'a str, )>,
     pub map_f32: Vec<(&'a str, f32, )>,
+    #[serde(with = "sentinel_str_sentinel")]
+    pub str_sentinel: Option<String>,
     pub default: u16,
     pub material: u16,
     pub alias: u16,
@@ -136,4 +139,30 @@ pub enum Enum8 {
 pub enum Enum16 {
     Empty = -128,
     FooBar = 1024,
+}
+
+mod sentinel_str_sentinel {
+    use serde::{Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        if value == "" {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(v) => serde::Serialize::serialize(v, serializer),
+            None => serde::Serialize::serialize(&"", serializer),
+        }
+    }
 }


### PR DESCRIPTION
 In ClickHouse it's common to use default values as "no value" sentinels instead of `Nullable` — empty string for `String` columns, `0` for integer columns etc.                                                       
                                                                                                                                                                                     
  Currently ch2rs has no way to handle this — sentinel columns are generated as plain types (`String`, `u32`), and the caller has to check for default values manually.              
                                                                                                                                 
  This PR adds a `-N <column>` flag that wraps the column type in `Option<T>` and generates a serde module that maps the type's default value to `None`:                             
                                                                                                                                              
  ```sh                                                                                                                                                                              
  ch2rs trades -S -D --owned -N user_name -N user_id         
  ```                                                                                                                
  Supported types: String, all integer types (U/Int 8–128), Float32/64. 
  Using -N on Nullable, Enum, Array, Date, or other complex types is rejected with a clear error.              
